### PR TITLE
レイアウトがスマホ画面で崩れていたので修正しました。#26

### DIFF
--- a/my-app/src/components/app-goal-and-task/CheckBox.jsx
+++ b/my-app/src/components/app-goal-and-task/CheckBox.jsx
@@ -16,6 +16,7 @@ const SButton = styled.button`
     margin: 0 2rem 0 0;
     font-size: 1.25rem;
     width: fit-content;
+    color: #333;
     &:hover {
         opacity: 0.5;
     }

--- a/my-app/src/components/app-goal-and-task/CreateButton.jsx
+++ b/my-app/src/components/app-goal-and-task/CreateButton.jsx
@@ -56,6 +56,7 @@ const SButton = styled.button`
     box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
     font-size: 1.25rem;
     padding: 0.5rem;
+    color: #333;
     @media (max-width: 73rem) {
         font-size: 1rem;
     }

--- a/my-app/src/components/app-goal-and-task/Form.jsx
+++ b/my-app/src/components/app-goal-and-task/Form.jsx
@@ -367,10 +367,10 @@ const SGoalInput = styled.input`
     margin-left: 1rem;
     font-family: 'Noto Sans JP', sans-serif;
     flex-grow: 1;
+    width: 80%;
     &:hover {
         opacity: 0.5;
     }
-    flex-glow: 1;
     @media (max-width: 73rem) {
         font-size: 1rem;
     }
@@ -461,6 +461,7 @@ const STaskInput = styled.input`
         opacity: 0.5;
     }
     flex-grow: 1;
+    width: 80%;
     @media (max-width: 73rem) {
         font-size: 1rem;
     }


### PR DESCRIPTION
- このブランチでやったこと
1.   タスクとゴールのインプットダグが起因していたスマホ画面でのレイアウトの崩れを修正しました。
2.   クリエイトボタンの文字色がスマホ画面では白色になっていたので修正しました。
3.   チェックボックスの文字色がスマホ画面では青色になっていたので修正しました。